### PR TITLE
lavender: Disable ext4 barrier flags for userdata

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -11,7 +11,7 @@
 # Non-A/B fstab.qcom variant
 #<src>                                                   <mnt_point>          <type>  <mnt_flags and options>                                                                         <fs_mgr_flags>
 /dev/block/bootdevice/by-name/system                     /                    ext4    ro,barrier=1,discard                                                                            wait,avb
-/dev/block/bootdevice/by-name/userdata                   /data                ext4    nosuid,nodev,barrier=1,noauto_da_alloc,noatime,lazytime                                         wait,check,fileencryption=ice,quota,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata                   /data                ext4    nosuid,nodev,nobarrier,noauto_da_alloc,noatime,lazytime                                         wait,check,fileencryption=ice,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/misc                       /misc                emmc    defaults                                                                                        defaults
 /dev/block/bootdevice/by-name/modem                      /vendor/firmware_mnt vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0    wait
 /dev/block/bootdevice/by-name/bluetooth                  /vendor/bt_firmware  vfat    ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:bt_firmware_file:s0 wait


### PR DESCRIPTION
* Can improve random read and write I/O performance
* We have enabled async_fsync in the kernel, so you
  don't have to worry about data corruption due to not
  submitted in time (commit=5).

Change-Id: I1318efce83fa4d41e6975d295458a12d7da87ad2